### PR TITLE
Move the exemple in the ENTRYPOINT to a CMD command

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,12 @@ _The binary produced for Amazon Linux 1 can be used to run [deno on AWS Lambda](
 
 For example:
 
+```sh
+$ docker run -it --init -p 1993:1993 -v $PWD:/app hayd/deno:alpine-0.35.0 --allow-net /app/main.ts
+```
+
+or
+
 ```Dockerfile
 FROM hayd/deno:alpine-0.35.0
 

--- a/alpine.dockerfile
+++ b/alpine.dockerfile
@@ -18,4 +18,5 @@ RUN addgroup -g 1993 -S deno \
 ENV DENO_DIR /deno-dir/
 
 
-ENTRYPOINT ["deno", "run", "https://deno.land/std/examples/welcome.ts"]
+ENTRYPOINT ["deno"]
+CMD ["https://deno.land/std/examples/welcome.ts"]

--- a/amazonlinux1.dockerfile
+++ b/amazonlinux1.dockerfile
@@ -69,4 +69,5 @@ COPY --from=0 /deno/target/release/deno /bin/deno
 ENV DENO_DIR /deno-dir/
 
 
-ENTRYPOINT ["deno", "run", "https://deno.land/std/examples/welcome.ts"]
+ENTRYPOINT ["deno"]
+CMD ["https://deno.land/std/examples/welcome.ts"]

--- a/debian.dockerfile
+++ b/debian.dockerfile
@@ -20,4 +20,5 @@ RUN useradd --uid 1993 --user-group deno \
 ENV DENO_DIR /deno-dir/
 
 
-ENTRYPOINT ["deno", "run", "https://deno.land/std/examples/welcome.ts"]
+ENTRYPOINT ["deno"]
+CMD ["https://deno.land/std/examples/welcome.ts"]

--- a/example/Dockerfile
+++ b/example/Dockerfile
@@ -12,4 +12,4 @@ RUN deno fetch deps.ts
 ADD . .
 RUN deno fetch main.ts
 
-ENTRYPOINT ["deno", "run", "--allow-net", "main.ts"]
+CMD ["run", "--allow-net", "main.ts"]

--- a/example/README.md
+++ b/example/README.md
@@ -1,7 +1,7 @@
-The ENTRYPOINT line in the Dockerfile determines what is run.
+The CMD line in the Dockerfile determines parameters passed to Deno.
 
 ```
-ENTRYPOINT ["deno", "run", "--allow-net", "main.ts"]
+CMD ["run", "--allow-net", "main.ts"]
 ```
 
 Note: That the listen port (1993), must match with the EXPOSED port in the Dockerfile.

--- a/ubuntu.dockerfile
+++ b/ubuntu.dockerfile
@@ -21,4 +21,5 @@ RUN useradd --uid 1993 --user-group deno \
 ENV DENO_DIR /deno-dir/
 
 
-ENTRYPOINT ["deno", "run", "https://deno.land/std/examples/welcome.ts"]
+ENTRYPOINT ["deno"]
+CMD ["https://deno.land/std/examples/welcome.ts"]


### PR DESCRIPTION
https://docs.docker.com/engine/reference/builder/#cmd

Avoid rewriting `deno` ever time :
```sh
  # before (using CMD, `--entrypoint "deno [url]"` not working)
$ docker run -it --rm --entrypoint deno hayd/deno:alpine-0.35.0 https://deno.land/std/examples/echo_server.ts

  # after
$ docker run -it --rm hayd/deno:alpine-0.35.0 https://deno.land/std/examples/echo_server.ts
```
and `docker run -it --rm hayd/deno:alpine-0.35.0` still executes the `https://deno.land/std/examples/welcome.ts`.

Very usefull for `docker-compose.yml` files with volumes (avoid Dockerfiles everywhere)