### PR TITLE
 Publish latest tags and OSes as tags 

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,7 @@ jobs:
       id: get_version
       run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
     - name: Publish Docker
-      uses: elgohr/Publish-Docker-Github-Action@2.7
+      uses: elgohr/Publish-Docker-Github-Action@2.14
       with:
         name: "hayd/${{ matrix.kind }}-deno"
         username: ${{ secrets.DOCKER_USERNAME }}
@@ -25,7 +25,7 @@ jobs:
         tags: "latest,${{ steps.get_version.outputs.VERSION }}"
     - name: Publish Docker Legacy
       if: matrix.kind != 'amazonlinux1'
-      uses: elgohr/Publish-Docker-Github-Action@2.7
+      uses: elgohr/Publish-Docker-Github-Action@2.14
       with:
         name: "hayd/deno"
         username: ${{ secrets.DOCKER_USERNAME }}
@@ -41,7 +41,7 @@ jobs:
       id: get_version
       run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
     - name: Publish Docker Legacy Alpine
-      uses: elgohr/Publish-Docker-Github-Action@2.7
+      uses: elgohr/Publish-Docker-Github-Action@2.14
       with:
         name: "hayd/deno"
         username: ${{ secrets.DOCKER_USERNAME }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,7 +22,7 @@ jobs:
         password: ${{ secrets.DOCKER_PASSWORD }}
         dockerfile: ${{ matrix.kind }}.dockerfile
         cache: true
-        tags: latest,${{ steps.get_version.outputs.VERSION }}
+        tags: "latest,${{ steps.get_version.outputs.VERSION }}"
     - name: Publish Docker Legacy
       if: matrix.kind != 'amazonlinux1'
       uses: elgohr/Publish-Docker-Github-Action@2.7
@@ -32,7 +32,7 @@ jobs:
         password: ${{ secrets.DOCKER_PASSWORD }}
         dockerfile: ${{ matrix.kind }}.dockerfile
         cache: true
-        tags: ${{ matrix.kind }},${{ matrix.kind }}-${{ steps.get_version.outputs.VERSION }}
+        tags: "${{ matrix.kind }},${{ matrix.kind }}-${{ steps.get_version.outputs.VERSION }}"
   build_alpine_latest:
     runs-on: ubuntu-latest
     steps:
@@ -48,4 +48,4 @@ jobs:
         password: ${{ secrets.DOCKER_PASSWORD }}
         dockerfile: alpine.dockerfile
         cache: true
-        tags: latest,${{ steps.get_version.outputs.VERSION }}
+        tags: "latest,${{ steps.get_version.outputs.VERSION }}"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,19 +17,35 @@ jobs:
     - name: Publish Docker
       uses: elgohr/Publish-Docker-Github-Action@2.7
       with:
-        name: "hayd/${{ matrix.kind }}-deno:${{ steps.get_version.outputs.VERSION }}"
+        name: "hayd/${{ matrix.kind }}-deno"
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
         dockerfile: ${{ matrix.kind }}.dockerfile
         cache: true
-        tag_names: true
+        tags: latest,${{ steps.get_version.outputs.VERSION }}
     - name: Publish Docker Legacy
       if: matrix.kind != 'amazonlinux1'
       uses: elgohr/Publish-Docker-Github-Action@2.7
       with:
-        name: "hayd/deno:${{ matrix.kind }}-${{ steps.get_version.outputs.VERSION }}"
+        name: "hayd/deno"
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
         dockerfile: ${{ matrix.kind }}.dockerfile
         cache: true
-        tag_names: true
+        tags: ${{ matrix.kind }},${{ matrix.kind }}-${{ steps.get_version.outputs.VERSION }}
+  build_alpine_latest:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: Get the version
+      id: get_version
+      run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
+    - name: Publish Docker Legacy Alpine
+      uses: elgohr/Publish-Docker-Github-Action@2.7
+      with:
+        name: "hayd/deno"
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
+        dockerfile: alpine.dockerfile
+        cache: true
+        tags: latest,${{ steps.get_version.outputs.VERSION }}

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ _The amazonlinux1 build is used to run [deno on AWS Lambda](https://github.com/h
 To run `main.ts` from your working directory:
 
 ```sh
-$ docker run -it --init -p 1993:1993 -v $PWD:/app hayd/alpine-deno:0.37.0 --allow-net /app/main.ts
+$ docker run -it --init -p 1993:1993 -v $PWD:/app hayd/alpine-deno:0.37.1 --allow-net /app/main.ts
 ```
 
 Here, `-p 1993:1993` maps port 1993 on the container to 1993 on the host,
@@ -28,7 +28,7 @@ Here, `-p 1993:1993` maps port 1993 on the container to 1993 on the host,
 ## As a Dockerfile
 
 ```Dockerfile
-FROM hayd/alpine-deno:0.37.0
+FROM hayd/alpine-deno:0.37.1
 
 EXPOSE 1993  # The port that your application listens to.
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ _The amazonlinux1 build is used to run [deno on AWS Lambda](https://github.com/h
 To run `main.ts` from your working directory:
 
 ```sh
-$ docker run -it --init -p 1993:1993 -v $PWD:/app hayd/alpine-deno:0.37.1 --allow-net /app/main.ts
+$ docker run -it --init -p 1993:1993 -v $PWD:/app hayd/alpine-deno:0.38.0 --allow-net /app/main.ts
 ```
 
 Here, `-p 1993:1993` maps port 1993 on the container to 1993 on the host,
@@ -28,7 +28,7 @@ Here, `-p 1993:1993` maps port 1993 on the container to 1993 on the host,
 ## As a Dockerfile
 
 ```Dockerfile
-FROM hayd/alpine-deno:0.37.1
+FROM hayd/alpine-deno:0.38.0
 
 EXPOSE 1993  # The port that your application listens to.
 

--- a/alpine-built.dockerfile
+++ b/alpine-built.dockerfile
@@ -46,7 +46,7 @@ RUN \
 FROM alpine:3.10.1 as deno-builder
 
 ENV DENO_BUILD_MODE=release
-ENV DENO_VERSION=0.37.1
+ENV DENO_VERSION=0.38.0
 
 RUN apk add --no-cache curl && \
     curl -fsSL https://github.com/denoland/deno/releases/download/v${DENO_VERSION}/deno_src.tar.gz --output deno.tar.gz && \

--- a/alpine-built.dockerfile
+++ b/alpine-built.dockerfile
@@ -46,7 +46,7 @@ RUN \
 FROM alpine:3.10.1 as deno-builder
 
 ENV DENO_BUILD_MODE=release
-ENV DENO_VERSION=0.37.0
+ENV DENO_VERSION=0.37.1
 
 RUN apk add --no-cache curl && \
     curl -fsSL https://github.com/denoland/deno/releases/download/v${DENO_VERSION}/deno_src.tar.gz --output deno.tar.gz && \

--- a/alpine.dockerfile
+++ b/alpine.dockerfile
@@ -1,6 +1,6 @@
 FROM frolvlad/alpine-glibc:alpine-3.10_glibc-2.29
 
-ENV DENO_VERSION=0.37.0
+ENV DENO_VERSION=0.37.1
 
 RUN apk add --no-cache curl \
  && curl -fsSL https://github.com/denoland/deno/releases/download/v${DENO_VERSION}/deno_linux_x64.gz \

--- a/alpine.dockerfile
+++ b/alpine.dockerfile
@@ -1,6 +1,6 @@
 FROM frolvlad/alpine-glibc:alpine-3.10_glibc-2.29
 
-ENV DENO_VERSION=0.37.1
+ENV DENO_VERSION=0.38.0
 
 RUN apk add --no-cache curl \
  && curl -fsSL https://github.com/denoland/deno/releases/download/v${DENO_VERSION}/deno_linux_x64.gz \

--- a/amazonlinux1.dockerfile
+++ b/amazonlinux1.dockerfile
@@ -28,7 +28,7 @@ RUN curl -fL https://github.com/llvm/llvm-project/releases/download/llvmorg-10.0
  && mv /tmp/clang+llvm-10.0.0-x86_64-linux-sles11.3 /tmp/clang
 ENV PATH=/tmp/clang-llvm/bin:$PATH
 
-ENV RUST_VERSION=1.41.0
+ENV RUST_VERSION=1.42.0
 RUN curl https://sh.rustup.rs -sSf \
   | sh -s -- --default-toolchain ${RUST_VERSION} -y
 ENV PATH=/root/.cargo/bin:$PATH

--- a/amazonlinux1.dockerfile
+++ b/amazonlinux1.dockerfile
@@ -33,7 +33,7 @@ RUN curl https://sh.rustup.rs -sSf \
   | sh -s -- --default-toolchain ${RUST_VERSION} -y
 ENV PATH=/root/.cargo/bin:$PATH
 
-ENV DENO_VERSION=0.37.1
+ENV DENO_VERSION=0.38.0
 
 RUN curl -fsSL https://github.com/denoland/deno/releases/download/v${DENO_VERSION}/deno_src.tar.gz \
          --output deno.tar.gz \

--- a/amazonlinux1.dockerfile
+++ b/amazonlinux1.dockerfile
@@ -33,7 +33,7 @@ RUN curl https://sh.rustup.rs -sSf \
   | sh -s -- --default-toolchain ${RUST_VERSION} -y
 ENV PATH=/root/.cargo/bin:$PATH
 
-ENV DENO_VERSION=0.37.0
+ENV DENO_VERSION=0.37.1
 
 RUN curl -fsSL https://github.com/denoland/deno/releases/download/v${DENO_VERSION}/deno_src.tar.gz \
          --output deno.tar.gz \

--- a/centos.dockerfile
+++ b/centos.dockerfile
@@ -1,6 +1,6 @@
 FROM centos:8.1.1911
 
-ENV DENO_VERSION=0.37.0
+ENV DENO_VERSION=0.37.1
 
 RUN curl -fsSL https://github.com/denoland/deno/releases/download/v${DENO_VERSION}/deno_linux_x64.gz \
          --output deno.gz \

--- a/centos.dockerfile
+++ b/centos.dockerfile
@@ -1,6 +1,6 @@
 FROM centos:8.1.1911
 
-ENV DENO_VERSION=0.37.1
+ENV DENO_VERSION=0.38.0
 
 RUN curl -fsSL https://github.com/denoland/deno/releases/download/v${DENO_VERSION}/deno_linux_x64.gz \
          --output deno.gz \

--- a/debian.dockerfile
+++ b/debian.dockerfile
@@ -1,6 +1,6 @@
 FROM debian:stable-20191014-slim
 
-ENV DENO_VERSION=0.37.0
+ENV DENO_VERSION=0.37.1
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get -qq update \

--- a/debian.dockerfile
+++ b/debian.dockerfile
@@ -1,6 +1,6 @@
 FROM debian:stable-20191014-slim
 
-ENV DENO_VERSION=0.37.1
+ENV DENO_VERSION=0.38.0
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get -qq update \

--- a/example/Dockerfile
+++ b/example/Dockerfile
@@ -1,4 +1,4 @@
-FROM hayd/alpine-deno:0.37.0
+FROM hayd/alpine-deno:0.37.1
 
 EXPOSE 1993
 

--- a/example/Dockerfile
+++ b/example/Dockerfile
@@ -1,4 +1,4 @@
-FROM hayd/alpine-deno:0.37.1
+FROM hayd/alpine-deno:0.38.0
 
 EXPOSE 1993
 

--- a/example/deps.ts
+++ b/example/deps.ts
@@ -1,1 +1,1 @@
-export { serve } from "https://deno.land/std@v0.37.0/http/server.ts";
+export { serve } from "https://deno.land/std@v0.37.1/http/server.ts";

--- a/example/deps.ts
+++ b/example/deps.ts
@@ -1,1 +1,1 @@
-export { serve } from "https://deno.land/std@v0.37.1/http/server.ts";
+export { serve } from "https://deno.land/std@v0.38.0/http/server.ts";

--- a/ubuntu.dockerfile
+++ b/ubuntu.dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:bionic-20200219
 
-ENV DENO_VERSION=0.37.0
+ENV DENO_VERSION=0.37.1
 
 RUN apt-get -qq update \
  && apt-get upgrade -y -o Dpkg::Options::="--force-confold" \

--- a/ubuntu.dockerfile
+++ b/ubuntu.dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:bionic-20200219
 
-ENV DENO_VERSION=0.37.1
+ENV DENO_VERSION=0.38.0
 
 RUN apt-get -qq update \
  && apt-get upgrade -y -o Dpkg::Options::="--force-confold" \


### PR DESCRIPTION
Bump to 0.38.0.

Closes #26.