### PR TITLE
Bump to Deno version 1.1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,18 +17,18 @@ _The amazonlinux1 build is used to run [deno on AWS Lambda](https://github.com/h
 
 To start the `deno` repl:
 ```sh
-$ docker run -it --init hayd/alpine-deno:1.1.0 repl
+$ docker run -it --init hayd/alpine-deno:1.1.1 repl
 ```
 
 To shell into the docker runtime:
 ```sh
-$ docker run -it --init --entrypoint sh hayd/alpine-deno:1.1.0
+$ docker run -it --init --entrypoint sh hayd/alpine-deno:1.1.1
 ```
 
 To run `main.ts` from your working directory:
 
 ```sh
-$ docker run -it --init -p 1993:1993 -v $PWD:/app hayd/alpine-deno:1.1.0 --allow-net /app/main.ts
+$ docker run -it --init -p 1993:1993 -v $PWD:/app hayd/alpine-deno:1.1.1 --allow-net /app/main.ts
 ```
 
 Here, `-p 1993:1993` maps port 1993 on the container to 1993 on the host,
@@ -39,7 +39,7 @@ Here, `-p 1993:1993` maps port 1993 on the container to 1993 on the host,
 ## As a Dockerfile
 
 ```Dockerfile
-FROM hayd/alpine-deno:1.1.0
+FROM hayd/alpine-deno:1.1.1
 
 EXPOSE 1993  # The port that your application listens to.
 
@@ -80,7 +80,7 @@ deno () {
     --volume $PWD:/app \
     --volume $HOME/.deno:/deno-dir \
     --workdir /app \
-    hayd/alpine-deno:1.1.0 \
+    hayd/alpine-deno:1.1.1 \
     "$@"
 }
 ```

--- a/alpine-built.dockerfile
+++ b/alpine-built.dockerfile
@@ -46,7 +46,7 @@ RUN \
 FROM alpine:3.10.1 as deno-builder
 
 ENV DENO_BUILD_MODE=release
-ENV DENO_VERSION=1.1.0
+ENV DENO_VERSION=1.1.1
 
 RUN apk add --no-cache curl && \
     curl -fsSL https://github.com/denoland/deno/releases/download/v${DENO_VERSION}/deno_src.tar.gz --output deno.tar.gz && \

--- a/alpine.dockerfile
+++ b/alpine.dockerfile
@@ -1,6 +1,6 @@
 FROM frolvlad/alpine-glibc:alpine-3.11_glibc-2.31
 
-ENV DENO_VERSION=1.1.0
+ENV DENO_VERSION=1.1.1
 
 RUN apk add --virtual .download --no-cache curl \
  && curl -fsSL https://github.com/denoland/deno/releases/download/v${DENO_VERSION}/deno-x86_64-unknown-linux-gnu.zip \

--- a/amazonlinux1.dockerfile
+++ b/amazonlinux1.dockerfile
@@ -28,12 +28,12 @@ RUN curl -fL https://github.com/llvm/llvm-project/releases/download/llvmorg-10.0
  && mv /tmp/clang+llvm-10.0.0-x86_64-linux-sles11.3 /tmp/clang
 ENV PATH=/tmp/clang-llvm/bin:$PATH
 
-ENV RUST_VERSION=1.43.0
+ENV RUST_VERSION=1.44.0
 RUN curl https://sh.rustup.rs -sSf \
   | sh -s -- --default-toolchain ${RUST_VERSION} -y
 ENV PATH=/root/.cargo/bin:$PATH
 
-ENV DENO_VERSION=1.1.0
+ENV DENO_VERSION=1.1.1
 
 RUN curl -fsSL https://github.com/denoland/deno/releases/download/v${DENO_VERSION}/deno_src.tar.gz \
          --output deno.tar.gz \

--- a/centos.dockerfile
+++ b/centos.dockerfile
@@ -1,6 +1,6 @@
 FROM centos:8.1.1911
 
-ENV DENO_VERSION=1.1.0
+ENV DENO_VERSION=1.1.1
 
 RUN yum makecache \
  && yum install unzip -y \

--- a/debian.dockerfile
+++ b/debian.dockerfile
@@ -1,6 +1,6 @@
 FROM debian:stable-20200327-slim
 
-ENV DENO_VERSION=1.1.0
+ENV DENO_VERSION=1.1.1
 ARG DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get -qq update \

--- a/example/Dockerfile
+++ b/example/Dockerfile
@@ -1,4 +1,4 @@
-FROM hayd/alpine-deno:1.1.0
+FROM hayd/alpine-deno:1.1.1
 
 EXPOSE 1993
 

--- a/example/deps.ts
+++ b/example/deps.ts
@@ -1,1 +1,1 @@
-export { serve } from "https://deno.land/std@0.57.0/http/server.ts";
+export { serve } from "https://deno.land/std@0.58.0/http/server.ts";

--- a/ubuntu.dockerfile
+++ b/ubuntu.dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:bionic-20200311
 
-ENV DENO_VERSION=1.1.0
+ENV DENO_VERSION=1.1.1
 
 RUN apt-get -qq update \
  && apt-get upgrade -y -o Dpkg::Options::="--force-confold" \


### PR DESCRIPTION
Updates Dockerfiles' Deno version to 1.1.1 and amazonlinux1.dockerfile to Rust version 1.44.0 since Deno upgraded to that version in https://github.com/denoland/deno/pull/6113