### PR TITLE
chore: bump to 1.6.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,19 +20,19 @@ and the [deno-lambda](https://github.com/hayd/deno-lambda) project._
 To start the `deno` repl:
 
 ```sh
-$ docker run -it --init hayd/alpine-deno:1.6.2 repl
+$ docker run -it --init hayd/alpine-deno:1.6.3 repl
 ```
 
 To shell into the docker runtime:
 
 ```sh
-$ docker run -it --init --entrypoint sh hayd/alpine-deno:1.6.2
+$ docker run -it --init --entrypoint sh hayd/alpine-deno:1.6.3
 ```
 
 To run `main.ts` from your working directory:
 
 ```sh
-$ docker run -it --init -p 1993:1993 -v $PWD:/app hayd/alpine-deno:1.6.2 run --allow-net /app/main.ts
+$ docker run -it --init -p 1993:1993 -v $PWD:/app hayd/alpine-deno:1.6.3 run --allow-net /app/main.ts
 ```
 
 Here, `-p 1993:1993` maps port 1993 on the container to 1993 on the host,
@@ -42,7 +42,7 @@ Here, `-p 1993:1993` maps port 1993 on the container to 1993 on the host,
 ## As a Dockerfile
 
 ```Dockerfile
-FROM hayd/alpine-deno:1.6.2
+FROM hayd/alpine-deno:1.6.3
 
 # The port that your application listens to.
 EXPOSE 1993
@@ -84,7 +84,7 @@ deno () {
     --volume $PWD:/app \
     --volume $HOME/.deno:/deno-dir \
     --workdir /app \
-    hayd/alpine-deno:1.6.2 \
+    hayd/alpine-deno:1.6.3 \
     "$@"
 }
 ```

--- a/alpine-built.dockerfile
+++ b/alpine-built.dockerfile
@@ -46,7 +46,7 @@ RUN \
 FROM alpine:3.10.1 as deno-builder
 
 ENV DENO_BUILD_MODE=release
-ENV DENO_VERSION=1.6.2
+ENV DENO_VERSION=1.6.3
 
 RUN apk add --no-cache curl && \
   curl -fsSL https://github.com/denoland/deno/releases/download/v${DENO_VERSION}/deno_src.tar.gz --output deno.tar.gz && \

--- a/alpine.dockerfile
+++ b/alpine.dockerfile
@@ -1,6 +1,6 @@
 FROM frolvlad/alpine-glibc
 
-ENV DENO_VERSION=1.6.2
+ENV DENO_VERSION=1.6.3
 
 RUN apk add --virtual .download --no-cache curl \
  && curl -fsSL https://github.com/denoland/deno/releases/download/v${DENO_VERSION}/deno-x86_64-unknown-linux-gnu.zip \

--- a/centos.dockerfile
+++ b/centos.dockerfile
@@ -1,6 +1,6 @@
 FROM centos:8
 
-ENV DENO_VERSION=1.6.2
+ENV DENO_VERSION=1.6.3
 
 RUN yum makecache \
  && yum install unzip -y \

--- a/debian.dockerfile
+++ b/debian.dockerfile
@@ -1,6 +1,6 @@
 FROM debian:stable-slim
 
-ENV DENO_VERSION=1.6.2
+ENV DENO_VERSION=1.6.3
 ARG DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get -qq update \

--- a/distroless.dockerfile
+++ b/distroless.dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.12.3
 
-ENV DENO_VERSION=1.6.2
+ENV DENO_VERSION=1.6.3
 
 RUN apk add --virtual .download --no-cache curl \
  && curl -fsSL https://github.com/denoland/deno/releases/download/v${DENO_VERSION}/deno-x86_64-unknown-linux-gnu.zip \
@@ -15,7 +15,7 @@ RUN apk add --virtual .download --no-cache curl \
 FROM gcr.io/distroless/cc
 COPY --from=0 /bin/deno /bin/deno
 
-ENV DENO_VERSION=1.6.2
+ENV DENO_VERSION=1.6.3
 ENV DENO_DIR /deno-dir/
 ENV DENO_INSTALL_ROOT /usr/local
 

--- a/example/Dockerfile
+++ b/example/Dockerfile
@@ -1,4 +1,4 @@
-FROM hayd/alpine-deno:1.6.2
+FROM hayd/alpine-deno:1.6.3
 
 EXPOSE 1993
 

--- a/ubuntu.dockerfile
+++ b/ubuntu.dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:20.04
 
-ENV DENO_VERSION=1.6.2
+ENV DENO_VERSION=1.6.3
 
 RUN apt-get -qq update \
  && apt-get upgrade -y -o Dpkg::Options::="--force-confold" \


### PR DESCRIPTION
Updates the Deno version to 1.6.3. 