### PR TITLE
change to a standard, explicit user creation

### DIFF
--- a/alpine.dockerfile
+++ b/alpine.dockerfile
@@ -11,8 +11,8 @@ RUN apk add --virtual .download --no-cache curl \
  && mv deno /bin/deno \
  && apk del .download
 
-RUN addgroup -g 1993 -S deno \
- && adduser -u 1993 -S deno -G deno \
+RUN addgroup --gid 1000 deno \
+ && adduser --uid 1000 --disabled-password deno --ingroup deno \
  && mkdir /deno-dir/ \
  && chown deno:deno /deno-dir/
 


### PR DESCRIPTION
used the long commands for readability. fixes: https://github.com/hayd/deno-docker/issues/126. im not sure if there are other edge cases where a non standard uid/gid would get in the way but it makes it better for vscode tooling.

if you dont mind being this explicit ill leave it as is, otherwise if we assume the `addgroup` and `adduser` defaults we can go this route but who knows if the defaults will ever change on alpines end:
```
addgroup deno
adduser --disabled-password deno --ingroup deno
```